### PR TITLE
Use `ToString` as a trait bound for string-like args

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,17 +81,19 @@ impl fmt::Display for XMLElement {
 
 impl XMLElement {
     /// Creates a new empty XML element using the given name for the tag.
-    pub fn new(name: &str) -> Self {
+    pub fn new(name: impl ToString) -> Self {
         XMLElement {
-            name: name.to_owned(),
+            name: name.to_string(),
             attributes: IndexMap::new(),
             content: XMLElementContent::Empty,
         }
     }
 
-    /// Adds an attribute to the XML element.
-    pub fn add_attribute(&mut self, name: &str, value: &str) {
-        self.attributes.insert(name.to_owned(), escape_str(value));
+    /// Adds an attribute to the XML element.  The attribute value can take any type which
+    /// implements [`Display`].
+    pub fn add_attribute(&mut self, name: impl ToString, value: impl ToString) {
+        self.attributes
+            .insert(name.to_string(), escape_str(&value.to_string()));
     }
 
     /// Adds a child element to the XML element.
@@ -125,11 +127,11 @@ impl XMLElement {
     /// # Panics
     ///
     /// Panics if the element is not empty.
-    pub fn add_text(&mut self, text: &str) {
+    pub fn add_text(&mut self, text: impl ToString) {
         use XMLElementContent::*;
         match self.content {
             Empty => {
-                self.content = Text(escape_str(text));
+                self.content = Text(escape_str(&text.to_string()));
             }
             _ => {
                 panic!("Attempted adding text to non-empty element.");


### PR DESCRIPTION
Very nice library!  It does exactly what I need, with no bells and whistles.

However, I find myself using types that aren't `&str` as attribute values or text content.  At the moment, I have to do something like this:
```rust
elem.add_attribute("x1", &p1.x.to_string());
elem.add_attribute("y1", &p1.y.to_string());
elem.add_attribute("x2", &p2.x.to_string());
elem.add_attribute("y2", &p2.y.to_string());
elem.add_attribute("stroke-linecap", "round");
```

This is very verbose, so this PR gives the arguments the `ToString` trait bound to allow any type (including `&str` and `String`) to be passed as an argument.  So that code now becomes much more succinct:
```rust
elem.add_attribute("x1", p1.x);
elem.add_attribute("y1", p1.y);
elem.add_attribute("x2", p2.x);
elem.add_attribute("y2", p2.y);
elem.add_attribute("stroke-linecap", "round");
```

All existing code still works, although it would likely call `to_string()` twice which would cause an unnecessary allocation (that LLVM will almost certainly remove).